### PR TITLE
Improve reliability of import with symbols and spaces

### DIFF
--- a/lib/insert.js
+++ b/lib/insert.js
@@ -8,11 +8,11 @@ module.exports = function(creds) {
     creds.forEach(function(c) {
         var cmd = '';
         if (c.username) {
-            cmd = 'echo "'+ c.password + '" | pass insert -e ' + c.location + '/' + c.username;
+            cmd = 'pass insert -e "' + c.location + '/' + c.username + '"';
         } else {
-            cmd = 'echo "'+ c.password + '" | pass insert -e Passwords/' + c.location;
+            cmd = 'pass insert -e "Passwords/' + c.location + '"';
         }
-        execSync(cmd);
+        execSync(cmd, {input: c.password});
         console.log('INFO: ' + (c.username || 'Password entry') + ' at ' + c.location + ' imported.');
     });
 


### PR DESCRIPTION
I ran into a number of problems trying to import my large 1Password vault, which boiled down to issues with executing commands through `execSync` and the underlying shell.
- I had usernames with spaces in the name. This was fixed by fully quoting the title.
- I had passwords with symbols that sh/bash/etc didn't like including in an echo. Instead I pass the password as the `input` option passed to `execSync`, which does what `echo` was doing.
