### PR TITLE
Fix .1pif JSON parsing

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2,7 +2,7 @@
 
 module.exports = function(onepifdata) {
 
-    var items = onepifdata.split(/\n\*\*\*.*?\*\*\*\n/);
+    var items = onepifdata.split(/\*\*\*[a-zA-Z0-9\-]{30,40}?\*\*\*/gm);
 
     var creds = [];
     var count_password = 0;
@@ -10,7 +10,7 @@ module.exports = function(onepifdata) {
 
     items.forEach(function(item) {
         if (item) {
-            var i = JSON.parse(item);
+            var i = JSON.parse(item.trim());
             var f = {
                 location: i.locationKey,
                 username: '',


### PR DESCRIPTION
The regexp included newline delimiters that are unnecessary (and
usuallly unreliable). Instead using .trim() on the product takes care of
any whitespace that could impact parsing.

Also, regexps should be as specific as possible when applicable. Using
.*? may work in some cases but in others will lead to failures.

Changes introduced to make it work on node v4.2.6.
